### PR TITLE
Fix/class names

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+.DS_Store
+node_modules
+/dist
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@jiayingy/vue-single-date-picker",
-  "version": "0.1.0",
+  "version": "0.3.8",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
+  "main": "./dist/vue-single-date-picker.common.js",
+  "files": [
+    "/dist"
+  ], 
   "repository": {
     "type": "git",
-    "url": "git://github.com/jiayingy/vue-single-date-picker"
+    "url": "git+git://github.com/jiayingy/vue-single-date-picker"
   },
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/CalendarDate.vue
+++ b/src/components/CalendarDate.vue
@@ -2,8 +2,9 @@
   <td>
     <div
       v-show="date"
-      class="date"
-      :class="{today: isToday, selected: isSelected}"
+      class="single-date-picker__date"
+      :class="{'single-date-picker__today': isToday, 
+               'single-date-picker__selected': isSelected}"
       @click="selectDate"
     >
       {{ date }}
@@ -36,7 +37,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.date {
+.single-date-picker__date {
   font-size: 10px;
   font-size: 14px;
   height: 30px;
@@ -47,12 +48,12 @@ export default {
   cursor: default;
 
   &:hover,
-  &.selected {
+  &.single-date-picker__selected {
     border-radius: 50%;
     border: 2px solid pink;
   }
 
-  &.today {
+  &.single-date-picker__today {
     border-radius: 50%;
     background-image: linear-gradient(to bottom right, #f1b4b9, #d2b0c3);
   }

--- a/src/components/CalendarMonth.vue
+++ b/src/components/CalendarMonth.vue
@@ -1,5 +1,5 @@
 <template>
-  <table class="calendar-month">
+  <table class="single-date-picker__calendar-month">
     <thead>
       <CalendarWeekHeader
         v-for="(day, index) in daysInWeek"
@@ -57,7 +57,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.calendar-month {
+.single-date-picker__calendar-month {
   width: 100%;
   padding: 10px;
 }

--- a/src/components/CalendarMonthHeader.vue
+++ b/src/components/CalendarMonthHeader.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="calendar-month-header">
+  <div class="single-date-picker__calendar-month-header">
     <div
-      class="arrow left"
+      class="single-date-picker__arrow left"
       @click="toggleMonth(-1)"
     >
       <i class="material-icons">
         keyboard_arrow_left
       </i>
     </div>
-    <div class="year">
+    <div class="single-date-picker__year">
       {{ fullMonth }} {{ year }}
     </div>
     <div
-      class="arrow right" 
+      class="single-date-picker__arrow right" 
       @click="toggleMonth(1)"
     >
       <i class="material-icons">
@@ -62,7 +62,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.calendar-month-header {
+.single-date-picker__calendar-month-header {
   padding: 15px;
   background-image: linear-gradient(to right, #e0caca, #d4b8ca, #c7a3b5);
   display: flex;
@@ -71,12 +71,12 @@ export default {
   align-items: center;
   color: #77505e;
 
-  .year {
+  .single-date-picker__year {
     font-weight: 900;
     font-size: 20px;
     text-transform: capitalize;
   }
-  .arrow {
+  .single-date-picker__arrow {
     cursor: pointer;
   }
 }

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 <template>
-  <div class="calendar-view">
+  <div class="single-date-picker__calendar-view">
     <CalendarMonthHeader
       :year="year"
       :month="month"
@@ -146,7 +146,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.calendar-view {
+.single-date-picker__calendar-view {
   max-width: 300px;
   background-color: white;
   border-radius: 10px;

--- a/src/components/CalendarWeekHeader.vue
+++ b/src/components/CalendarWeekHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <th>
-    <div class="calendar-week-header">
+    <div class="single-date-picker__calendar-week-header">
       {{ day }}
     </div>
   </th>
@@ -18,7 +18,7 @@ export default {
 </script>
 
 <style scoped>
-.calendar-week-header {
+.single-date-picker__calendar-week-header {
   margin-top: 15px;
   color: #77505e;
 }


### PR DESCRIPTION
# Motivation
Class names were too general. May result in styles being overwritten when installed as a third-party package in other projects.

# Solution
Added `single-date-picker__<class-name>` prefix to all class names