### PR TITLE
Add feature: change first day of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Create component in your template
 ### Props 
 |Props|arguments|remarks|
 |:--|:--|:--|
-|date|```{ year: <Number>, month: <Number>, date: <Number> }```|E.g. 1 Jan 2020 <br> {year: 2020, month: 0, date: 1}| 
+|date|```{ year: <Number>, month: <Number>, date: <Number> }```|E.g. 1 Jan 2020 <br> {year: 2020, month: 0, date: 1}|
+|first-day-of-week|```firstDayOfWeek: <Number>```|(0: Sunday ... 6: Saturday) <br> E.g. start week on Monday <br> :first-day-of-week="1"| 
 
 ### Events 
 |events|arguments|remarks|

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -13,7 +13,7 @@
       :dates-per-week="datesPerWeek"
       :is-today="isToday"
       :is-selected="isSelected"
-      :first-day-of-week="firstDayOfWeek"
+      :week-start-day="weekStartDay"
       @selectDate="selectDate"
     />
   </div>
@@ -38,7 +38,8 @@ export default {
     },
     firstDayOfWeek: {
       type: Number,
-      default: 0
+      default: 0,
+      validator: (value) => (value >= 0) && (value <= 6)
     }
   },
   data() {
@@ -49,6 +50,7 @@ export default {
       todayYear: 0,
       todayMonth: 0,
       selectedDate: null,
+      weekStartDay: 0,
     }
   },
   computed: {
@@ -56,7 +58,7 @@ export default {
       return new Date(this.year, this.month + 1, 0).getDate();
     },
     firstDay() {
-      return new Date(this.year, this.month, 1).getDay() - this.firstDayOfWeek;
+      return new Date(this.year, this.month, 1).getDay() - this.weekStartDay;
     },
     lastDay() {
       return new Date(this.year, this.month + 1, 0).getDay();
@@ -129,6 +131,7 @@ export default {
     this.todayYear = date.getFullYear();
     this.todayMonth = date.getMonth();
 
+    this.weekStartDay = (this.firstDayOfWeek >= 0 && this.firstDayOfWeek <= 6) ? this.firstDayOfWeek : 0;
   },
   methods: {
     generateDatesInWeek(startDate, startDay, numDays) {

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -13,6 +13,7 @@
       :dates-per-week="datesPerWeek"
       :is-today="isToday"
       :is-selected="isSelected"
+      :first-day-of-week="firstDayOfWeek"
       @selectDate="selectDate"
     />
   </div>
@@ -34,6 +35,10 @@ export default {
     date: {
       type: Object,
       default: () => null
+    },
+    firstDayOfWeek: {
+      type: Number,
+      default: 0
     }
   },
   data() {
@@ -51,7 +56,7 @@ export default {
       return new Date(this.year, this.month + 1, 0).getDate();
     },
     firstDay() {
-      return new Date(this.year, this.month, 1).getDay();
+      return new Date(this.year, this.month, 1).getDay() - this.firstDayOfWeek;
     },
     lastDay() {
       return new Date(this.year, this.month + 1, 0).getDay();

--- a/src/components/CalendarMonth.vue
+++ b/src/components/CalendarMonth.vue
@@ -41,6 +41,10 @@ export default {
     isSelected: {
       type: Number,
       default: 0,
+    },
+    firstDayOfWeek: {
+      type: Number,
+      default: 0
     }
   },
   data() {
@@ -48,9 +52,18 @@ export default {
       daysInWeek: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
     }
   },
+  created() {
+    this.rotateDaysInWeek(this.daysInWeek, this.firstDayOfWeek);
+  },
   methods: {
     selectDate(date) {
       this.$emit('selectDate', date);
+    },
+    rotateDaysInWeek(daysInWeek, shifts) {
+      while(shifts--) {
+        var temp = daysInWeek.shift();
+        daysInWeek.push(temp);
+      }
     }
   }
 }

--- a/src/components/CalendarMonth.vue
+++ b/src/components/CalendarMonth.vue
@@ -42,9 +42,9 @@ export default {
       type: Number,
       default: 0,
     },
-    firstDayOfWeek: {
+    weekStartDay: {
       type: Number,
-      default: 0
+      default: 0,
     }
   },
   data() {
@@ -53,7 +53,7 @@ export default {
     }
   },
   created() {
-    this.rotateDaysInWeek(this.daysInWeek, this.firstDayOfWeek);
+    this.rotateDaysInWeek(this.daysInWeek, this.weekStartDay);
   },
   methods: {
     selectDate(date) {


### PR DESCRIPTION
## Description
Add new feature to change the first day of the week, which is Sunday by default.
It is done by injecting a property to the root component.

## Example
`<calendar-view :first-day-of-week="1" />` sets Monday as the first day of the week. Then, all days in the month view will be shifted accordingly and the week header would be like `M T W T F S S`.